### PR TITLE
Use a specific version of poetry (#56)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           python-version: 3.8
 
       - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
 
       - name: Build and publish
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.8
 
       - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
 
       - name: Set up Poetry environment
         run: poetry install --no-root


### PR DESCRIPTION
poetry 2.x is not compatible with Python 3.8, so we will use the last version from the 1.x series for now.